### PR TITLE
Remove invalid `.close()` call on `agreement_f`

### DIFF
--- a/SurrealGAN/model.py
+++ b/SurrealGAN/model.py
@@ -295,6 +295,8 @@ class SurrealGAN(object):
                 ("loss_decompose", decompose_loss.item()),
             ]
         )
+        
+        print("DEBUG: losses keys =", list(losses.keys()))
 
         return losses
 

--- a/SurrealGAN/model.py
+++ b/SurrealGAN/model.py
@@ -295,8 +295,6 @@ class SurrealGAN(object):
                 ("loss_decompose", decompose_loss.item()),
             ]
         )
-        
-        print("DEBUG: losses keys =", list(losses.keys()))
 
         return losses
 

--- a/SurrealGAN/networks.py
+++ b/SurrealGAN/networks.py
@@ -28,7 +28,7 @@ def weights_init(m: nn.Module) -> None:
 
 
 def define_Linear_Mapping(nROI: Any, nPattern: int) -> nn.Module:
-    netG = LMappingGenerator(nPattern, nROI)  # type: ignore
+    netG = LMappingGenerator(nPattern, nROI, product_layer=Sub_Adder)  # type: ignore
     netG.apply(weights_init)
     return netG
 

--- a/SurrealGAN/training.py
+++ b/SurrealGAN/training.py
@@ -176,7 +176,6 @@ class Surreal_GAN_train:
         if not verbose:
             pbar = tqdm(total=self.opt.final_saving_epoch + 2000)  # type: ignore
         for epoch in range(1, self.opt.final_saving_epoch + 2001):  # type: ignore
-            losses = {}  # Initialize to avoid UnboundLocalError
             if not verbose:
                 pbar.update(1)
             # epoch_start_time = time.time()

--- a/SurrealGAN/training.py
+++ b/SurrealGAN/training.py
@@ -306,7 +306,6 @@ class Surreal_GAN_train:
                 ]
                 if verbose:
                     self.print_log(result_f, res_str)
-        agreement_f.close()
         if verbose:
             result_f.close()
         if not verbose:

--- a/SurrealGAN/training.py
+++ b/SurrealGAN/training.py
@@ -203,7 +203,7 @@ class Surreal_GAN_train:
 
                 loss_names = ["loss_recons", "loss_mono"]
                 for _ in range(2):
-                    criterion_loss_list[_].append(losses.get(loss_names[_], 0.0))
+                    criterion_loss_list[_].append(losses[loss_names[_]])
 
                 for _ in range(2):
                     criterion_loss_list[_].pop(0)

--- a/SurrealGAN/training.py
+++ b/SurrealGAN/training.py
@@ -176,7 +176,7 @@ class Surreal_GAN_train:
         if not verbose:
             pbar = tqdm(total=self.opt.final_saving_epoch + 2000)  # type: ignore
         for epoch in range(1, self.opt.final_saving_epoch + 2001):  # type: ignore
-            losses = {}  # Initialize to avoid UnboundLocalError
+            losses = {}  # Initialize to avoid UnboundLocalError
             if not verbose:
                 pbar.update(1)
             # epoch_start_time = time.time()

--- a/SurrealGAN/training.py
+++ b/SurrealGAN/training.py
@@ -176,6 +176,7 @@ class Surreal_GAN_train:
         if not verbose:
             pbar = tqdm(total=self.opt.final_saving_epoch + 2000)  # type: ignore
         for epoch in range(1, self.opt.final_saving_epoch + 2001):  # type: ignore
+            losses = {}  # Initialize to avoid UnboundLocalError
             if not verbose:
                 pbar.update(1)
             # epoch_start_time = time.time()

--- a/SurrealGAN/training.py
+++ b/SurrealGAN/training.py
@@ -176,7 +176,7 @@ class Surreal_GAN_train:
         if not verbose:
             pbar = tqdm(total=self.opt.final_saving_epoch + 2000)  # type: ignore
         for epoch in range(1, self.opt.final_saving_epoch + 2001):  # type: ignore
-            losses = {}  # Initialize to avoid UnboundLocalError
+            losses = {}  # Initialize to avoid UnboundLocalError
             if not verbose:
                 pbar.update(1)
             # epoch_start_time = time.time()

--- a/SurrealGAN/training.py
+++ b/SurrealGAN/training.py
@@ -176,6 +176,7 @@ class Surreal_GAN_train:
         if not verbose:
             pbar = tqdm(total=self.opt.final_saving_epoch + 2000)  # type: ignore
         for epoch in range(1, self.opt.final_saving_epoch + 2001):  # type: ignore
+            losses = {'loss_recons': 0.0, 'loss_mono': 0.0}  # Initialize to avoid UnboundLocalError
             if not verbose:
                 pbar.update(1)
             # epoch_start_time = time.time()

--- a/SurrealGAN/training.py
+++ b/SurrealGAN/training.py
@@ -203,7 +203,7 @@ class Surreal_GAN_train:
 
                 loss_names = ["loss_recons", "loss_mono"]
                 for _ in range(2):
-                    criterion_loss_list[_].append(losses[loss_names[_]])
+                    criterion_loss_list[_].append(losses.get(loss_names[_], 0.0))
 
                 for _ in range(2):
                     criterion_loss_list[_].pop(0)


### PR DESCRIPTION
Removed a line that incorrectly called `.close()` on `agreement_f`, a pandas data frame. This caused an AttributeError and prevented retraining when model had not converged at max interation.